### PR TITLE
Improved HTML escaping and fixed lint warnings

### DIFF
--- a/jquery.highlighttextarea.js
+++ b/jquery.highlighttextarea.js
@@ -74,12 +74,15 @@
         		that.spacer = '\\b';
         	}
 
-        function htmlDecode(input){
-          var e = document.createElement('div');
-          e.innerHTML = input;
-          return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+        function htmlDecode(input) {
+          return $('<div/>').text(input).html();
         }
 
+        // Encode text before inserting into <div> so that the textarea and
+        // overlay don't get out if sync when the textarea contains something 
+        // HTML (e.g. "&amp;" or <foo>).
+        text = htmlDecode(text);
+        
         var matches = [];
         $.each(this.settings.words, function(color, words) {
           var wordsRe = htmlDecode(words.join("|"));

--- a/jquery.highlighttextarea.js
+++ b/jquery.highlighttextarea.js
@@ -7,9 +7,9 @@
 (function($){
     "use strict";
 
-    var isNumeric = function( n ) {
+    var isNumeric = function(n) {
       return !isNaN(parseFloat(n)) && isFinite(n);
-    }
+    };
 
     // Highlighter CLASS DEFINITON
     // ===============================
@@ -122,8 +122,7 @@
                 text = Utilities.strInsert(text, range.end, '</mark>');
 
                 var mark = '<mark style="background-color:'+ range.color +';"';
-                if (range.class != null)
-                {
+                if (range.class !== null) {
                     mark += 'class="' + range.class + '"';
                 }
                 mark += ">";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-highlighttextarea",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "author": {
     "name": "Gary Sieling",
     "homepage": "https://www.garysieling.com/blog"


### PR DESCRIPTION
It now escapes HTML before inserting into <div> so that the textarea and overlay don't get out of sync when the textarea contains HTML (e.g. text like "&amp;" or "<b>").

This *may* cause incompatiblity with some existing regular expressions used for highlighting so have bumped the revision number from 3.1 to 3.2, although I think those would be edge cases (and easily resolved by changing the regex to expect escaped html).