### PR TITLE
Add regex boundaries

### DIFF
--- a/jquery.highlighttextarea.js
+++ b/jquery.highlighttextarea.js
@@ -100,7 +100,7 @@
               matches.push(match);
               if (evaluated.indexOf(match) === -1) {
                 text = text.replace(
-                  new RegExp(match, that.regParam), 
+                  new RegExp(that.spacer + match + that.spacer, that.regParam), 
                     function(innerMatch, start, contents) {
                       var encodedMatch = innerMatch
                         .replace(/[&"<>]/g, function (c) {


### PR DESCRIPTION
Add fix for issue when highlighted part of word. Basically here I just wanted to highlight geo but geo could be part of geozone word so that part highlighted too.

![hightlight](https://user-images.githubusercontent.com/17146578/33258412-295d1e3c-d362-11e7-8741-80ee52f4df05.png)

Expected behavior
![hightlight-2](https://user-images.githubusercontent.com/17146578/33259585-fba1dcfe-d365-11e7-95c2-50392d6429f8.png)

