### PR TITLE
Set container width '100%' in updateCss

### DIFF
--- a/jquery.highlighttextarea.js
+++ b/jquery.highlighttextarea.js
@@ -358,7 +358,7 @@
         this.$container.css({
             'top':        Utilities.toPx(this.$el.css('margin-top')) + Utilities.toPx(this.$el.css('border-top-width')),
             'left':     Utilities.toPx(this.$el.css('margin-left')) + Utilities.toPx(this.$el.css('border-left-width')),
-            'width':    this.$el.width(),
+            'width':    '100%',
             'height': this.$el.height()
         });
 


### PR DESCRIPTION
Before, container width is set in updateCss to input element's width. When the input element's width changes from 100px to 300px, container remains 100px, which causes improper display. 

![2017-12-11_104044](https://user-images.githubusercontent.com/13349592/33813599-c3851a7a-de5f-11e7-8c25-f13c49a8ab8e.png)

To solve this, width could be set to `100%`.

![2017-12-11_103833](https://user-images.githubusercontent.com/13349592/33813556-7ce86a54-de5f-11e7-8138-f86a41472285.png)

