### PR TITLE
Replace all words at one time.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,6 +46,9 @@ module.exports = function(grunt) {
                         'jquery.highlighttextarea.js'
                     ]
                 }
+            },
+            options: {
+                reporterOutput: ''
             }
         }
     });

--- a/jquery.highlighttextarea.js
+++ b/jquery.highlighttextarea.js
@@ -81,44 +81,44 @@
         }
 
         // Encode text before inserting into <div> so that the textarea and
-        // overlay don't get out if sync when the textarea contains something 
+        // overlay don't get out if sync when the textarea contains something
         // HTML (e.g. "&amp;" or <foo>).
         text = htmlDecode(text);
-        
+
         var matches = [];
-        $.each(this.settings.words, function(color, words) {
-          var wordsRe = htmlDecode(words.join("|"));
+
+        var wordColorMap = {};
+        $.each(this.settings.words, function (color, words) {
+          $.each(words, function (index, word) {
+            wordColorMap[word] = color;
+          });
+        });
+
+        $.each(wordColorMap, function (word, color) {
+          var wordsRe = htmlDecode(word);
           var re = that.spacer + '(' + wordsRe + ')' + that.spacer;
           var regex = new RegExp(re, that.regParam);
 
           var wordMatches = text.match(regex);
           if (wordMatches) {
-            var evaluated = [];
-            $.each(words, function(index, match) {
-              match = htmlDecode(match);
+            word = htmlDecode(word);
+            matches.push(word);
+            text = text.replace(
+              new RegExp(that.spacer + word + that.spacer, that.regParam),
+                function(innerMatch, start, contents) {
+                  var encodedMatch = innerMatch
+                    .replace(/[&"<>]/g, function (c) {
+                      return {
+                        '&': "&amp;",
+                        '"': "&quot;",
+                        '<': "&lt;",
+                        '>': "&gt;"
+                      }[c];
+                  });
 
-              matches.push(match);
-              if (evaluated.indexOf(match) === -1) {
-                text = text.replace(
-                  new RegExp(that.spacer + match + that.spacer, that.regParam), 
-                    function(innerMatch, start, contents) {
-                      var encodedMatch = innerMatch
-                        .replace(/[&"<>]/g, function (c) {
-                          return {
-                            '&': "&amp;",
-                            '"': "&quot;",
-                            '<': "&lt;",
-                            '>': "&gt;"
-                          }[c];
-                      });
-
-                      return '<mark style="background-color:'+ color +';">' + encodedMatch + '</mark>';
-                    }
-                  );
-
-                evaluated.push(match);
-              }
-            });
+                  return '<mark style="background-color:'+ color +';">' + encodedMatch + '</mark>';
+                }
+              );
           }
         });
 
@@ -592,7 +592,7 @@
         return out;
     };
 
-    
+
     /*
      * Formats a list of ranges into a hash of arrays (Color => Ranges list)
      * @param ranges {mixed}

--- a/jquery.highlighttextarea.js
+++ b/jquery.highlighttextarea.js
@@ -81,44 +81,44 @@
         }
 
         // Encode text before inserting into <div> so that the textarea and
-        // overlay don't get out if sync when the textarea contains something 
+        // overlay don't get out if sync when the textarea contains something
         // HTML (e.g. "&amp;" or <foo>).
         text = htmlDecode(text);
-        
+
         var matches = [];
-        $.each(this.settings.words, function(color, words) {
-          var wordsRe = htmlDecode(words.join("|"));
+
+        var wordColorMap = {};
+        $.each(this.settings.words, function (color, words) {
+          $.each(words, function (index, word) {
+            wordColorMap[word] = color;
+          });
+        });
+
+        $.each(wordColorMap, function (word, color) {
+          var wordsRe = htmlDecode(word);
           var re = that.spacer + '(' + wordsRe + ')' + that.spacer;
           var regex = new RegExp(re, that.regParam);
 
           var wordMatches = text.match(regex);
           if (wordMatches) {
-            var evaluated = [];
-            $.each(words, function(index, match) {
-              match = htmlDecode(match);
+            word = htmlDecode(word);
+            matches.push(word);
+            text = text.replace(
+              new RegExp(that.spacer + word + that.spacer, that.regParam),
+                function(innerMatch, start, contents) {
+                  var encodedMatch = innerMatch
+                    .replace(/[&"<>]/g, function (c) {
+                      return {
+                        '&': "&amp;",
+                        '"': "&quot;",
+                        '<': "&lt;",
+                        '>': "&gt;"
+                      }[c];
+                  });
 
-              matches.push(match);
-              if (evaluated.indexOf(match) === -1) {
-                text = text.replace(
-                  new RegExp(that.spacer + match + that.spacer, that.regParam), 
-                    function(innerMatch, start, contents) {
-                      var encodedMatch = innerMatch
-                        .replace(/[&"<>]/g, function (c) {
-                          return {
-                            '&': "&amp;",
-                            '"': "&quot;",
-                            '<': "&lt;",
-                            '>': "&gt;"
-                          }[c];
-                      });
-
-                      return '<mark style="background-color:'+ color +';">' + encodedMatch + '</mark>';
-                    }
-                  );
-
-                evaluated.push(match);
-              }
-            });
+                  return '<mark style="background-color:'+ color +';">' + encodedMatch + '</mark>';
+                }
+              );
           }
         });
 
@@ -592,7 +592,7 @@
         return out;
     };
 
-    
+
     /*
      * Formats a list of ranges into a hash of arrays (Color => Ranges list)
      * @param ranges {mixed}
@@ -695,3 +695,5 @@
         });
     };
 }(window.jQuery || window.Zepto));
+
+// vim: sw=2 ts=2


### PR DESCRIPTION
As #78 mentioned, words with any chars in `'<mark style="background-color:'+ color +';">' + encodedMatch + '</mark>'` elements could cause wrong replacement if replacing word one by one.

To fix this. all words are joined as one regexp to replace text at one time.

Ex:         

    words: [
      {
        color: '#ADF0FF',
        words: ['abc']
      },
      {
        color: 'blue',
        words: ['-']
      }
    ],

![image](https://user-images.githubusercontent.com/13349592/38234621-fd793b68-3750-11e8-93f3-4961c574896c.png)